### PR TITLE
Document high-complexity tasks in README and fix per-task chart labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,11 +255,19 @@ Tasks live under `tasks/`. Two types:
 | `typescript-circuit-breaker` | vibe | TypeScript (Docker) | Brownfield: fix circuit-breaker bugs |
 | `bedrock-sentiment` | vibe | AWS / Python | Migrate Comprehend → Bedrock (rubric graded) |
 | `geotrack-duplicate-device` | vibe | Vue.js / AWS | Prevent duplicate IoT device assignment (rubric) |
+| `event-sourcing-cqrs` | vibe | Python (stdlib) | Greenfield high-complexity: event-sourcing/CQRS bank system (7 files, 32 tests) |
+| `multitenant-rbac-api` | vibe | Python / FastAPI | Greenfield high-complexity: multi-tenant RBAC document API (7 files, 30 tests) |
+| `multitenant-workflow-engine` | vibe | Python / FastAPI | Greenfield high-complexity: workflow state machine + SLA tracking (9 files, 38 tests) |
+| `distributed-task-processor` | vibe | Python / FastAPI | Greenfield high-complexity: plugin task processor + event bus (12 files, 52 tests) |
+| `ecommerce-order-saga` | vibe | Python / FastAPI | Greenfield high-complexity: order saga with compensation (15 files, 66 tests) |
+| `ml-pipeline-orchestrator` | vibe | Python / FastAPI | Greenfield high-complexity: ML pipeline orchestrator + registry (14 files, 64 tests) |
+| `platform-as-a-service` | vibe | Python / FastAPI | Greenfield high-complexity: multi-tenant PaaS backend (16 files, 72 tests) |
 | `auth-feature` | spec-driven | Python | JWT auth: login, logout, refresh |
 
 Select tasks with `task_ids:` in your config. Omit it to run everything.
 
 > Rubric-graded tasks need `judge_model`. Docker tasks need Docker + prebuilt images.
+> The seven high-complexity tasks (`event-sourcing-cqrs` through `platform-as-a-service`) are greenfield multi-file applications (7-16 files, 30-72 pytest scenarios each) that stress multi-file architecture and cross-cutting concerns; they take ~5-22 min per run versus under 2 min for the single-file tasks.
 
 ## How verification works
 

--- a/agent_cost_bench/reporter/templates/_styles.html
+++ b/agent_cost_bench/reporter/templates/_styles.html
@@ -32,7 +32,9 @@
   .na { color: var(--muted); font-style: italic; }
   .cost { color: var(--cost); font-variant-numeric: tabular-nums; }
   .chart-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+  .chart-grid-full { display: grid; grid-template-columns: 1fr; gap: 20px; }
   .chart-box { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 16px; }
+  .chart-box .tall { position: relative; height: 540px; }
   .chart-box h3 { margin: 0 0 12px; }
   details { background: var(--card); border: 1px solid var(--border); border-radius: 8px; margin-top: 6px; }
   details summary { padding: 10px 12px; cursor: pointer; font-size: 13px; }

--- a/agent_cost_bench/reporter/templates/report_cli_compare.html
+++ b/agent_cost_bench/reporter/templates/report_cli_compare.html
@@ -67,9 +67,9 @@
     <div class="chart-box"><h3>Avg Duration (s)</h3><canvas id="latChart"></canvas></div>
   </div>
   <h3 style="margin:28px 0 14px;">Per-Task Breakdown — each CLI on every task</h3>
-  <div class="chart-grid">
-    <div class="chart-box"><h3>Cost per Run by Task (USD)</h3><canvas id="costByTaskChart"></canvas></div>
-    <div class="chart-box"><h3>Duration by Task (s)</h3><canvas id="latByTaskChart"></canvas></div>
+  <div class="chart-grid-full">
+    <div class="chart-box"><h3>Cost per Run by Task (USD)</h3><div class="tall"><canvas id="costByTaskChart"></canvas></div></div>
+    <div class="chart-box"><h3>Duration by Task (s)</h3><div class="tall"><canvas id="latByTaskChart"></canvas></div></div>
   </div>
   {% endif %}
 
@@ -206,9 +206,10 @@ workspace: {{ r.workspace_path }}</pre>
       data: { labels: taskLabels, datasets },
       options: {
         responsive: true,
+        maintainAspectRatio: false,
         plugins: { legend: { display: true, labels: { color: tickColor } } },
         scales: {
-          x: { grid: { color: gridColor }, ticks: { color: tickColor } },
+          x: { grid: { color: gridColor }, ticks: { color: tickColor, autoSkip: false, maxRotation: 90, minRotation: 90 } },
           y: { grid: { color: gridColor }, ticks: { color: tickColor }, beginAtZero: true,
                title: { display: true, text: yLabel, color: tickColor } }
         }


### PR DESCRIPTION
Follow-up to #2 (which added the high-complexity task fixtures). Two small, low-risk changes.

## README
Adds the seven greenfield multi-file tasks (`event-sourcing-cqrs`, `multitenant-rbac-api`, `multitenant-workflow-engine`, `distributed-task-processor`, `ecommerce-order-saga`, `ml-pipeline-orchestrator`, `platform-as-a-service`) to the Included tasks table, with a note on their scale (7-16 files, 30-72 pytest scenarios, ~5-22 min/run). The task folders merged in #2 but weren't listed in the table.

## Reporter (HTML report only)
The per-task 'Cost per Run by Task' and 'Duration by Task' charts hid/clipped labels when a report had many tasks (Chart.js autoSkip). This forces all labels to render (rotated, full-width, taller charts). No change to benchmarking, scoring, or cost logic.

## Testing
Regenerated reports at both extremes (2-task and 21-task): all labels render, valid HTML, no breakage.