### PR TITLE
fix(status): treat a failed turn as transient even when the CLI exits 0

### DIFF
--- a/agent_cost_bench/models.py
+++ b/agent_cost_bench/models.py
@@ -769,15 +769,30 @@ class PhaseResult:
 
     @property
     def transient_error(self) -> bool:
+        combined = f"{self.stdout}\n{self.stderr}".lower()
+
+        # Some CLIs report a failed turn in their JSON stream but still exit 0
+        # (observed: Codex emits {"type":"turn.failed"} after an upstream
+        # "internal server error" and exits cleanly). Those runs produce no
+        # usage telemetry, so without this check they were scored as a normal
+        # PASS/FAIL with null cost — silently understating that CLI's spend and
+        # comparing unequal task sets. Detect them regardless of exit code.
+        hard_failures = (
+            '"type":"turn.failed"',
+            '"type": "turn.failed"',
+        )
+        if any(s in combined for s in hard_failures):
+            return True
+
         if self.success:
             return False
-        combined = f"{self.stdout}\n{self.stderr}".lower()
         signatures = (
             "having trouble responding",
             "failed to receive the next message",
             "failed to send the request",
             "dispatch failure",
             "error sending request for url",
+            "internal server error",
             "tool approval required but --no-interactive",
         )
         return any(s in combined for s in signatures)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,7 @@ from agent_cost_bench.models import (
     BenchConfig,
     CompareMode,
     CostSource,
+    PhaseResult,
     Target,
     TaskMode,
 )
@@ -181,3 +182,43 @@ def test_phase_result_timed_out_marker():
     assert ok.timed_out is False
     other = PhaseResult(phase="spec", success=False, duration_seconds=1.0, error="CLI exited with code 2")
     assert other.timed_out is False
+
+
+# ---------------------------------------------------------------------------
+# turn.failed must be treated as transient even when the CLI exits 0
+# ---------------------------------------------------------------------------
+
+
+def test_turn_failed_is_transient_despite_clean_exit():
+    """Codex emits {"type":"turn.failed"} after an upstream error but still exits
+    0. Such runs carry no usage telemetry, so if they aren't flagged the harness
+    scores them PASS/FAIL with null cost — understating that CLI's spend and
+    silently comparing unequal task sets."""
+    p = PhaseResult(
+        phase="vibe",
+        success=True,  # exit code 0
+        duration_seconds=1.0,
+        stdout='{"type":"error","message":"Internal server error"}\n'
+               '{"type":"turn.failed","error":{"message":"Internal server error"}}',
+    )
+    assert p.transient_error is True
+
+
+def test_internal_server_error_on_failure_is_transient():
+    p = PhaseResult(
+        phase="vibe",
+        success=False,
+        duration_seconds=1.0,
+        stderr="unexpected status 500: Internal server error",
+    )
+    assert p.transient_error is True
+
+
+def test_clean_successful_run_is_not_transient():
+    p = PhaseResult(
+        phase="vibe",
+        success=True,
+        duration_seconds=1.0,
+        stdout='{"type":"turn.completed","usage":{"input_tokens":10}}',
+    )
+    assert p.transient_error is False


### PR DESCRIPTION
## Problem

`PhaseResult.transient_error` returns early on `self.success`, so it only inspects output for
runs that exited non-zero. Some CLIs report a failed turn inside their JSON stream but still
**exit 0**, and those runs slip through.

Observed with `codex exec --json` during an upstream outage:

```json
{"type":"error","message":"Internal server error"}
{"type":"turn.failed","error":{"message":"Internal server error"}}
```

...followed by exit code 0. Because no `turn.completed` event was emitted,
`parse_codex_usage` returned an empty `Usage()`, so the run was recorded with
`cost_usd: None` and then scored as a normal PASS/FAIL against whatever files happened to be
in the workspace.

Two consequences, both silent:

1. **Spend is understated.** The run consumed real upstream capacity but contributes 0 to the
   cost totals.
2. **The comparison stops being like-for-like.** In a 21-task run, two cells were affected, so
   the summary compared one CLI over 21 tasks against another over 19 — with nothing in the
   report indicating it. Both affected runs were reported as PASSED.

`TaskStatus.UNAVAILABLE` already exists for exactly this case (service/infra failure rather
than a model quality result), so this routes such runs there.

## Changes

- `models.py`: check for `turn.failed` **before** the `self.success` early return; add
  `"internal server error"` to the transient signature list
- `tests/test_models.py`: three regression tests — exit-0 `turn.failed`, non-zero internal
  server error, and a clean successful run that must **not** be flagged

## Scope

`transient_error` is CLI-agnostic. The `turn.failed` marker is Codex-specific in practice,
but the added `"internal server error"` signature benefits any CLI that surfaces that string
on a genuine failure. Runs that succeed normally are unaffected — covered by the third test.

Full test suite passes locally (131 tests).
