### PR TITLE
[terraform-serverless-spa] Fix CodeQL URL-substring alert in verify test

### DIFF
--- a/tasks/vibe/terraform-serverless-spa/verify/tests/test_spa.py
+++ b/tasks/vibe/terraform-serverless-spa/verify/tests/test_spa.py
@@ -162,7 +162,9 @@ def test_has_iam_role(raw):
 
 
 def test_lambda_trust_policy(raw):
-    assert "lambda.amazonaws.com" in raw, \
+    # Match the service principal as a complete, quoted token (not a bare
+    # substring) so it can't match at an arbitrary position in the source.
+    assert re.search(r'"lambda\.amazonaws\.com"', raw), \
         "Lambda execution role does not trust lambda.amazonaws.com"
 
 


### PR DESCRIPTION
## What

Resolves the HIGH-severity CodeQL alert **`py/incomplete-url-substring-sanitization`** (code-scanning alert #1) in `tasks/vibe/terraform-serverless-spa/verify/tests/test_spa.py`.

## Change

`test_lambda_trust_policy` checked for the Lambda service principal with a bare substring containment:

```python
assert "lambda.amazonaws.com" in raw
```

Because that matches the domain at any position, a spoofed principal such as `"notlambda.amazonaws.com.evil.com"` would satisfy it. Replaced with an anchored, quoted-token match:

```python
assert re.search(r'"lambda\.amazonaws\.com"', raw)
```

This requires the principal to appear as a complete quoted token — exactly how Terraform renders a service principal — so it can no longer match at an arbitrary position.

## Verification

Ran the real `_raw_lower()` + `test_lambda_trust_policy()` against synthesized workspaces:

| Scenario | Result |
|---|---|
| `jsonencode` → `Service = "lambda.amazonaws.com"` | passes |
| heredoc JSON → `"Service": "lambda.amazonaws.com"` | passes |
| `aws_iam_policy_document` → `identifiers = ["lambda.amazonaws.com"]` | passes |
| spoof → `"notlambda.amazonaws.com.evil.com"` | rejected (old check wrongly passed) |
| missing principal | rejected |

No regression on valid Terraform; the spoofed principal the old check accepted is now rejected. The alert auto-closes once this merges and CodeQL re-scans `main`.
