### PR TITLE
testing and had issues with dashboard. was this a python version issu…

### DIFF
--- a/tasks/vibe/dashboard/verify/test_dashboard.py
+++ b/tasks/vibe/dashboard/verify/test_dashboard.py
@@ -46,11 +46,23 @@ def _free_port() -> int:
         return s.getsockname()[1]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def app_client():
-    mod = importlib.import_module("main")
-    from starlette.testclient import TestClient
-    return TestClient(mod.app)
+    """Function-scoped fixture: reimports main module each time to reset state."""
+    # Remove cached module so global state (todos dict, next_id) resets
+    if "main" in sys.modules:
+        del sys.modules["main"]
+    # Change to workspace dir so FileResponse("index.html") resolves correctly
+    old_cwd = os.getcwd()
+    os.chdir(WS)
+    try:
+        mod = importlib.import_module("main")
+        from starlette.testclient import TestClient
+        yield TestClient(mod.app)
+    finally:
+        os.chdir(old_cwd)
+        if "main" in sys.modules:
+            del sys.modules["main"]
 
 
 @pytest.fixture(scope="module")
@@ -80,7 +92,9 @@ def test_index_html_exists():
 def test_list_initially_empty(app_client):
     r = app_client.get("/api/todos")
     assert r.status_code == 200
-    assert isinstance(r.json(), list)
+    data = r.json()
+    assert isinstance(data, list)
+    assert len(data) == 0, f"expected empty list, got {len(data)} items"
 
 
 def test_create_todo(app_client):


### PR DESCRIPTION
…es of was it that the code is wrong?

  It was the test code that was wrong, not a Python version issue.

  The models' code was correct — both produced valid FastAPI apps that work perfectly. The problem was the test fixture:

  - @pytest.fixture(scope=module) meant the main module was imported once and shared across all test functions

  - Since the models (correctly) store todos in a module-level todos = {} dict, items created by test_create_todo were still there when test_list_initially_empty ran, and state accumulated across every test

  - The FileResponse(index.html) relative path also only works when the working directory is the workspace — the old tests never set that

  The Python 3.9 str | None syntax error I hit during local verification was just an artifact of this machine's default Python — the actual bench harness runs on 3.12 where that syntax is fine. It was a red

  herring in my debugging, not the cause of the original failure.

  TL;DR: The tests had a shared-state bug. Both models scored 56% because of the test, not because of their code.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
